### PR TITLE
OpenAPI 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# 🛠️ Sonar OpenApi (plugin) ![Release](https://img.shields.io/badge/release-1.0.5-purple) ![Swagger](https://img.shields.io/badge/-openapi-%23Clojure?style=flat&logo=swagger&logoColor=white) ![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=flat&logo=openjdk&logoColor=white)  [![License: LGPL v3](https://img.shields.io/badge/license-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0) 
+# 🛠️ Sonar OpenApi (plugin) ![Release](https://img.shields.io/badge/release-1.1.0-purple) ![Swagger](https://img.shields.io/badge/-openapi-%23Clojure?style=flat&logo=swagger&logoColor=white) ![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=flat&logo=openjdk&logoColor=white)  [![License: LGPL v3](https://img.shields.io/badge/license-LGPL_v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0) 
 
 Sonar OpenApi (plugin) is a code analyzer for OpenAPI specifications,  is the spiritual successor of [SonarOpenApi](https://github.com/societe-generale/sonar-openapi), carrying on from the point where it left off with support of Apiaddicts community.
 

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
         <artifactId>dosonarapi</artifactId>
-        <version>1.0.5</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/openapi-front-end/pom.xml
+++ b/openapi-front-end/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
+++ b/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
@@ -87,7 +87,7 @@ public enum OpenApi31Grammar implements GrammarRuleKey {
     b.setRootRule(ROOT);
 
     b.rule(ROOT).is(b.object(
-      b.mandatoryProperty("openapi", b.firstOf("3.0.0", "3.0.1", "3.0.2", "3.0.3")),
+      b.mandatoryProperty("openapi", "3.1.0"),
       b.mandatoryProperty("info", INFO),
       b.property("servers", b.array(SERVER)),
       b.mandatoryProperty("paths", PATHS),

--- a/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
+++ b/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
@@ -1,0 +1,478 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.sonar.sslr.grammar.GrammarRuleKey;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.YamlGrammarBuilder;
+
+@java.lang.SuppressWarnings("squid:S1192") // Voluntarily ignoring string constants redefinitions in this file
+public enum OpenApi31Grammar implements GrammarRuleKey {
+  ROOT,
+  INFO,
+  PATHS,
+  COMPONENTS,
+  PARAMETER,
+  RESPONSE,
+  SECURITY_SCHEME,
+  SECURITY_REQUIREMENT,
+  TAG,
+  REF,
+  EXTERNAL_DOC,
+  CONTACT,
+  LICENSE,
+
+  PATH,
+  OPERATION,
+  OPERATION_WEBHOOKS,
+  LINK,
+  CALLBACK,
+  RESPONSES,
+  REQUEST_BODY,
+
+  SCHEMA,
+  WEBHOOK,
+  WEBHOOKS,
+  DISCRIMINATOR,
+  HEADER,
+  EXAMPLE,
+  XML,
+  SERVER,
+  SERVER_VARIABLE,
+  HTTP_SECURITY_SCHEME,
+  API_KEY_SECURITY_SCHEME,
+  OAUTH2_SECURITY_SCHEME,
+  OPENID_SECURITY_SCHEME,
+  MEDIA_TYPE,
+  ENCODING,
+  FLOWS,
+  IMPLICIT_FLOW,
+  PASSWORD_FLOW,
+  CREDENTIALS_FLOW,
+  AUTH_FLOW,
+  SCHEMAS_COMPONENT,
+  WEBHOOKS_COMPONENT,
+  RESPONSES_COMPONENT,
+  PARAMETERS_COMPONENT,
+  EXAMPLES_COMPONENT,
+  BODIES_COMPONENT,
+  HEADERS_COMPONENT,
+  SECURITY_SCHEMES,
+  LINKS_COMPONENT,
+  CALLBACKS_COMPONENT,
+  SCHEMA_PROPERTIES,
+  DESCRIPTION;
+
+  private static final String EXTENSION_PATTERN = "^x-.*";
+
+  public static YamlGrammarBuilder create() {
+    YamlGrammarBuilder b = new YamlGrammarBuilder();
+    b.setRootRule(ROOT);
+
+    b.rule(ROOT).is(b.object(
+      b.mandatoryProperty("openapi", b.firstOf("3.0.0", "3.0.1", "3.0.2", "3.0.3")),
+      b.mandatoryProperty("info", INFO),
+      b.property("servers", b.array(SERVER)),
+      b.mandatoryProperty("paths", PATHS),
+      b.property("components", COMPONENTS),
+      b.property("security", b.array(SECURITY_REQUIREMENT)),
+      b.property("tags", b.array(TAG)),
+      b.property("externalDocs", EXTERNAL_DOC),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(REF).is(b.object(
+      b.mandatoryProperty("$ref", b.string())));
+    b.rule(EXTERNAL_DOC).is(b.object(
+      b.property("description", DESCRIPTION),
+      b.mandatoryProperty("url", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+
+    b.rule(DESCRIPTION).is(b.string()).skip();
+    buildInfo(b);
+    buildServer(b);
+    buildPaths(b);
+    buildComponents(b);
+    buildSecurityDefinitions(b);
+    buildTags(b);
+
+    return b;
+  }
+
+  private static void buildTags(YamlGrammarBuilder b) {
+    b.rule(TAG).is(b.object(
+      b.mandatoryProperty("name", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("externalDocs", EXTERNAL_DOC),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+
+  private static void buildSecurityDefinitions(YamlGrammarBuilder b) {
+    b.rule(SECURITY_SCHEME).is(
+      b.firstOf(HTTP_SECURITY_SCHEME, API_KEY_SECURITY_SCHEME, OAUTH2_SECURITY_SCHEME, OPENID_SECURITY_SCHEME));
+    b.rule(HTTP_SECURITY_SCHEME).is(b.object(
+      b.discriminant("type", "http"),
+      b.property("description", DESCRIPTION),
+      b.mandatoryProperty("scheme", b.string()),
+      b.property("bearerFormat", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();
+    b.rule(API_KEY_SECURITY_SCHEME).is(b.object(
+      b.discriminant("type", "apiKey"),
+      b.property("description", DESCRIPTION),
+      b.mandatoryProperty("name", b.string()),
+      b.mandatoryProperty("in", b.firstOf("query", "header", "cookie")),
+      b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();
+    b.rule(OAUTH2_SECURITY_SCHEME).is(b.object(
+      b.discriminant("type", "oauth2"),
+      b.property("description", DESCRIPTION),
+      b.mandatoryProperty("flows", FLOWS),
+      b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();
+    b.rule(OPENID_SECURITY_SCHEME).is(b.object(
+      b.discriminant("type", "openIdConnect"),
+      b.property("description", DESCRIPTION),
+      b.mandatoryProperty("openIdConnectUrl", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();
+    b.rule(FLOWS).is(b.object(
+      b.property("implicit", IMPLICIT_FLOW),
+      b.property("password", PASSWORD_FLOW),
+      b.property("clientCredentials", CREDENTIALS_FLOW),
+      b.property("authorizationCode", AUTH_FLOW),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(IMPLICIT_FLOW).is(b.object(
+      b.mandatoryProperty("authorizationUrl", b.string()),
+      b.property("refreshUrl", b.string()),
+      b.mandatoryProperty("scopes", b.object(
+        b.patternProperty(".*", b.string()))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(PASSWORD_FLOW).is(b.object(
+      b.mandatoryProperty("tokenUrl", b.string()),
+      b.property("refreshUrl", b.string()),
+      b.mandatoryProperty("scopes", b.object(
+        b.patternProperty(".*", b.string()))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(CREDENTIALS_FLOW).is(b.object(
+      b.mandatoryProperty("tokenUrl", b.string()),
+      b.property("refreshUrl", b.string()),
+      b.mandatoryProperty("scopes", b.object(
+        b.patternProperty(".*", b.string()))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(AUTH_FLOW).is(b.object(
+      b.mandatoryProperty("authorizationUrl", b.string()),
+      b.mandatoryProperty("tokenUrl", b.string()),
+      b.property("refreshUrl", b.string()),
+      b.mandatoryProperty("scopes", b.object(
+        b.patternProperty(".*", b.string()))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(SECURITY_REQUIREMENT).is(b.object(
+      b.patternProperty(".*", b.array(b.string()))));
+  }
+
+  private static void buildCallbacks(YamlGrammarBuilder b) {
+    b.rule(CALLBACK).is(b.object(
+      b.patternProperty("^[^x].*", PATH),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(LINK).is(b.object(
+      b.property("operationRef", b.string()),
+      b.property("operationId", b.string()),
+      b.property("parameters", b.object(
+        b.patternProperty(".*", b.anything()))),
+      b.property("requestBody", b.anything()),
+      b.property("description", DESCRIPTION),
+      b.property("server", SERVER),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+
+  private static void buildResponses(YamlGrammarBuilder b) {
+    b.rule(RESPONSES).is(b.object(
+      b.property("default", b.firstOf(RESPONSE, REF)),
+      b.patternProperty("^[0-9xX]+", b.firstOf(RESPONSE, REF)),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(RESPONSE).is(b.object(
+      b.mandatoryProperty("description", DESCRIPTION),
+      b.property("headers", b.object(
+        b.patternProperty(".*", b.firstOf(REF, HEADER)))),
+      b.property("content", b.object(
+        b.patternProperty(".*", MEDIA_TYPE))),
+      b.property("links", b.object(
+        b.patternProperty(".*", b.firstOf(REF, LINK)))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(HEADER).is(b.object(
+      b.property("description", DESCRIPTION),
+      b.property("required", b.bool()),
+      b.property("deprecated", b.bool()),
+      b.property("allowEmptyValue", b.bool()),
+
+      b.property("style", "simple"),
+      b.property("explode", b.bool()),
+      b.property("allowReserved", b.bool()),
+      b.property("schema", b.firstOf(REF, SCHEMA)),
+      b.property("example", b.anything()),
+      b.property("examples", b.object(
+        b.patternProperty(".*", b.firstOf(REF, EXAMPLE)))),
+      b.property("content", b.object(
+        b.patternProperty(".*", MEDIA_TYPE))),
+
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(EXAMPLE).is(b.object(
+      b.property("summary", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("value", b.anything()),
+      b.property("externalValue", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+
+  private static void buildParameters(YamlGrammarBuilder b) {
+    b.rule(PARAMETER).is(b.object(
+      b.mandatoryProperty("name", b.string()),
+      b.mandatoryProperty("in", b.firstOf("path", "query", "header", "cookie")),
+      b.property("description", DESCRIPTION),
+      b.property("required", b.bool()),
+      b.property("deprecated", b.bool()),
+      b.property("allowEmptyValue", b.bool()),
+
+      b.property("style", b.firstOf("matrix", "label", "form", "simple", "spaceDelimited", "pipeDelimited", "deepObject")),
+      b.property("explode", b.bool()),
+      b.property("allowReserved", b.bool()),
+      b.property("schema", b.firstOf(REF, SCHEMA)),
+      b.property("example", b.anything()),
+      b.property("examples", b.object(
+        b.patternProperty(".*", b.firstOf(REF, EXAMPLE)))),
+      b.property("content", b.object(
+        b.patternProperty(".*", MEDIA_TYPE))),
+
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(REQUEST_BODY).is(b.object(
+      b.property("description", DESCRIPTION),
+      b.property("required", b.bool()),
+      b.property("content", b.object(
+        b.patternProperty(".*", b.firstOf(REF, MEDIA_TYPE)))),
+
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(MEDIA_TYPE).is(b.object(
+      b.property("schema", b.firstOf(REF, SCHEMA)),
+      b.property("example", b.anything()),
+      b.property("examples", b.object(
+        b.patternProperty(".*", b.firstOf(REF, EXAMPLE)))),
+      b.property("encoding", b.object(
+        b.patternProperty(".*", ENCODING))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(ENCODING).is(b.object(
+      b.property("contentType", b.string()),
+      b.property("headers", b.object(
+        b.patternProperty(".*", b.firstOf(REF, HEADER)))),
+      b.property("style", b.firstOf("matrix", "label", "form", "simple", "spaceDelimited", "pipeDelimited", "deepObject")),
+      b.property("explode", b.bool()),
+      b.property("allowReserved", b.bool()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+
+  private static void buildComponents(YamlGrammarBuilder b) {
+    b.rule(COMPONENTS).is(b.object(
+      b.property("schemas", SCHEMAS_COMPONENT),
+      b.property("webhooks", WEBHOOKS_COMPONENT),
+      b.property("responses", RESPONSES_COMPONENT),
+      b.property("parameters", PARAMETERS_COMPONENT),
+      b.property("examples", EXAMPLES_COMPONENT),
+      b.property("requestBodies", BODIES_COMPONENT),
+      b.property("headers", HEADERS_COMPONENT),
+      b.property("securitySchemes", SECURITY_SCHEMES),
+      b.property("links", LINKS_COMPONENT),
+      b.property("callbacks", CALLBACKS_COMPONENT),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(SCHEMAS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, SCHEMA))));
+    b.rule(WEBHOOKS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, WEBHOOK))));
+    b.rule(RESPONSES_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, RESPONSE))));
+    b.rule(PARAMETERS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, PARAMETER))));
+    b.rule(EXAMPLES_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, EXAMPLE))));
+    b.rule(BODIES_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, REQUEST_BODY))));
+    b.rule(HEADERS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, HEADER))));
+    b.rule(SECURITY_SCHEMES).is(b.object(b.patternProperty(".*", b.firstOf(REF, SECURITY_SCHEME))));
+    b.rule(LINKS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, LINK))));
+    b.rule(CALLBACKS_COMPONENT).is(b.object(b.patternProperty(".*", b.firstOf(REF, CALLBACK))));
+
+    buildParameters(b);
+    buildResponses(b);
+    buildSchema(b);
+    buildWebhooks(b);
+    buildCallbacks(b);
+  }
+
+  private static void buildSchema(YamlGrammarBuilder b) {
+    b.rule(SCHEMA).is(b.object(
+      b.property("title", b.string()),
+      b.property("multipleOf", b.firstOf(b.integer(), b.floating())),
+      b.property("exclusiveMaximum", b.firstOf(b.integer(), b.floating())),
+      b.property("exclusiveMinimum", b.firstOf(b.integer(), b.floating())),
+      b.property("maxLength", b.integer()),
+      b.property("minLength", b.integer()),
+      b.property("pattern", b.string()),
+      b.property("maxItems", b.integer()),
+      b.property("minItems", b.integer()),
+      b.property("uniqueItems", b.bool()),
+      b.property("maxProperties", b.integer()),
+      b.property("minProperties", b.integer()),
+      b.property("required", b.array(b.string())),
+      b.property("enum", b.array(b.anything())),
+      b.property("type", b.firstOf(b.string(), b.array(b.string()))),
+      b.property("contentMediaType", b.string()),
+      b.property("contentEncoding", b.string()),
+      b.property("allOf", b.array(b.firstOf(REF, SCHEMA))),
+      b.property("oneOf", b.array(b.firstOf(REF, SCHEMA))),
+      b.property("anyOf", b.array(b.firstOf(REF, SCHEMA))),
+      b.property("not", b.firstOf(REF, SCHEMA)),
+      b.property("items", b.firstOf(REF, SCHEMA)),
+      b.property("properties", SCHEMA_PROPERTIES),
+      b.property("$schema", b.string()),
+      b.property("additionalProperties", b.firstOf(b.bool(), REF, SCHEMA)),
+      b.property("description", DESCRIPTION),
+      b.property("format", b.string()),
+      b.property("default", b.anything()),
+      b.property("nullable", b.bool()),
+      b.property("discriminator", DISCRIMINATOR),
+      b.property("readOnly", b.bool()),
+      b.property("writeOnly", b.bool()),
+      b.property("xml", XML),
+      b.property("externalDocs", EXTERNAL_DOC),
+      b.property("examples", b.array(b.anything())),
+      b.property("deprecated", b.bool()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(SCHEMA_PROPERTIES).is(b.object(b.patternProperty(".*", b.firstOf(REF, SCHEMA))));
+    b.rule(DISCRIMINATOR).is(b.object(
+      b.property("propertyName", b.string()),
+      b.property("mapping", b.object(
+        b.patternProperty(".*", b.string())))));
+    b.rule(XML).is(b.object(
+      b.property("name", b.string()),
+      b.property("namespace", b.string()),
+      b.property("prefix", b.string()),
+      b.property("attribute", b.bool()),
+      b.property("wrapped", b.bool()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+}
+
+  private static void buildWebhooks(YamlGrammarBuilder b) {
+    b.rule(WEBHOOKS).is(b.object(
+      b.property("webhooks", WEBHOOK),  // Usar una propiedad simple en lugar de patternProperty
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(WEBHOOK).is(b.object(
+      b.property("$ref", b.string()),
+      b.property("summary", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("get", OPERATION),
+      b.property("put", OPERATION),
+      b.property("post", OPERATION),
+      b.property("delete", OPERATION),
+      b.property("options", OPERATION),
+      b.property("head", OPERATION),
+      b.property("patch", OPERATION),
+      b.property("trace", OPERATION),
+      b.property("servers", b.array(SERVER)),
+      b.property("parameters", b.array(b.firstOf(REF, PARAMETER))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(OPERATION_WEBHOOKS).is(b.object(
+      b.property("tags", b.array(b.string())),
+      b.property("summary", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("externalDocs", EXTERNAL_DOC),
+      b.property("operationId", b.string()),
+      b.property("parameters", b.array(b.firstOf(REF, PARAMETER))),
+      b.property("requestBody", b.firstOf(REF, REQUEST_BODY)),
+      b.mandatoryProperty("responses", RESPONSES),
+      b.property("callbacks", b.object(
+        b.patternProperty(".*", b.firstOf(REF, CALLBACK)))),
+      b.property("deprecated", b.bool()),
+      b.property("security", b.array(SECURITY_REQUIREMENT)),
+      b.property("servers", b.array(SERVER)),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+}
+
+
+
+  private static void buildPaths(YamlGrammarBuilder b) {
+    b.rule(PATHS).is(b.object(
+      b.patternProperty("^/.*", PATH),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(PATH).is(b.object(
+      b.property("$ref", b.string()),
+      b.property("summary", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("get", OPERATION),
+      b.property("put", OPERATION),
+      b.property("post", OPERATION),
+      b.property("delete", OPERATION),
+      b.property("options", OPERATION),
+      b.property("head", OPERATION),
+      b.property("patch", OPERATION),
+      b.property("trace", OPERATION),
+      b.property("servers", b.array(SERVER)),
+      b.property("parameters", b.array(b.firstOf(REF, PARAMETER))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+    b.rule(OPERATION).is(b.object(
+      b.property("tags", b.array(b.string())),
+      b.property("summary", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("externalDocs", EXTERNAL_DOC),
+      b.property("operationId", b.string()),
+      b.property("parameters", b.array(b.firstOf(REF, PARAMETER))),
+      b.property("requestBody", b.firstOf(REF, REQUEST_BODY)),
+      b.mandatoryProperty("responses", RESPONSES),
+      b.property("callbacks", b.object(
+        b.patternProperty(".*", b.firstOf(REF, CALLBACK)))),
+      b.property("deprecated", b.bool()),
+      b.property("security", b.array(SECURITY_REQUIREMENT)),
+      b.property("servers", b.array(SERVER)),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+
+  private static void buildServer(YamlGrammarBuilder b) {
+    b.rule(SERVER).is(b.object(
+      b.mandatoryProperty("url", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("variables", b.object(
+        b.patternProperty(".*", SERVER_VARIABLE))),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+
+    b.rule(SERVER_VARIABLE).is(b.object(
+      b.property("enum", b.array(b.string())),
+      b.mandatoryProperty("default", b.string()),
+      b.property("description", DESCRIPTION),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+
+  }
+
+  private static void buildInfo(YamlGrammarBuilder b) {
+    b.rule(INFO).is(b.object(
+      b.mandatoryProperty("title", b.string()),
+      b.property("description", DESCRIPTION),
+      b.property("termsOfService", b.string()),
+      b.property("contact", CONTACT),
+      b.property("license", LICENSE),
+      b.mandatoryProperty("version", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+
+    b.rule(CONTACT).is(b.object(
+      b.property("name", b.string()),
+      b.property("url", b.string()),
+      b.property("email", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+
+    b.rule(LICENSE).is(b.object(
+      b.mandatoryProperty("name", b.string()),
+      b.property("url", b.string()),
+      b.patternProperty(EXTENSION_PATTERN, b.anything())));
+  }
+}

--- a/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
+++ b/openapi-front-end/src/main/java/org/apiaddicts/apitools/dosonarapi/api/v31/OpenApi31Grammar.java
@@ -57,6 +57,7 @@ public enum OpenApi31Grammar implements GrammarRuleKey {
   SERVER_VARIABLE,
   HTTP_SECURITY_SCHEME,
   API_KEY_SECURITY_SCHEME,
+  MUTUALTLS_SECURITY_SCHEME,
   OAUTH2_SECURITY_SCHEME,
   OPENID_SECURITY_SCHEME,
   MEDIA_TYPE,
@@ -123,7 +124,7 @@ public enum OpenApi31Grammar implements GrammarRuleKey {
 
   private static void buildSecurityDefinitions(YamlGrammarBuilder b) {
     b.rule(SECURITY_SCHEME).is(
-      b.firstOf(HTTP_SECURITY_SCHEME, API_KEY_SECURITY_SCHEME, OAUTH2_SECURITY_SCHEME, OPENID_SECURITY_SCHEME));
+      b.firstOf(HTTP_SECURITY_SCHEME, API_KEY_SECURITY_SCHEME, OAUTH2_SECURITY_SCHEME, OPENID_SECURITY_SCHEME, MUTUALTLS_SECURITY_SCHEME));
     b.rule(HTTP_SECURITY_SCHEME).is(b.object(
       b.discriminant("type", "http"),
       b.property("description", DESCRIPTION),
@@ -136,6 +137,9 @@ public enum OpenApi31Grammar implements GrammarRuleKey {
       b.mandatoryProperty("name", b.string()),
       b.mandatoryProperty("in", b.firstOf("query", "header", "cookie")),
       b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();
+    b.rule(MUTUALTLS_SECURITY_SCHEME).is(b.object(
+      b.discriminant("type", "mutualTLS"),
+      b.patternProperty(EXTENSION_PATTERN, b.anything()))).skip();  
     b.rule(OAUTH2_SECURITY_SCHEME).is(b.object(
       b.discriminant("type", "oauth2"),
       b.property("description", DESCRIPTION),

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/ExamplesTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/ExamplesTest.java
@@ -1,0 +1,40 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class ExamplesTest extends BaseNodeTest<OpenApi31Grammar> {
+
+  @Test
+  public void examples_schemas() {
+    JsonNode node = parseResource(OpenApi31Grammar.SCHEMA, "/models/v31/examples.yaml");
+
+    JsonNode properties = node.at("/properties");
+    assertPropertyKeys(properties).containsExactlyInAnyOrder("os");
+
+    JsonNode osProperty = properties.at("/os");
+    assertEquals("string", osProperty, "/type");
+    assertElements(node, "/properties/os/examples").containsExactly("fedora", "ubuntu");
+
+  }
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/ExclusiveMinimumMaximumTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/ExclusiveMinimumMaximumTest.java
@@ -1,0 +1,43 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class ExclusiveMinimumMaximumTest extends BaseNodeTest<OpenApi31Grammar> {
+
+  @Test
+  public void can_parse_schema_with_exclusive_minimum_maximum() {
+    JsonNode node = parseResource(OpenApi31Grammar.SCHEMA, "/models/v31/minimummaximum.yaml");
+
+    JsonNode properties = node.at("/properties");
+    assertPropertyKeys(properties).containsExactlyInAnyOrder("age", "price");
+
+    JsonNode ageProperty = properties.at("/age");
+    assertEquals("integer", ageProperty, "/type");
+    assertEquals("7", ageProperty, "/exclusiveMinimum");
+
+    JsonNode priceProperty = properties.at("/price");
+    assertEquals("number", priceProperty, "/type");
+    assertEquals("100", priceProperty, "/exclusiveMaximum");
+  }
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/FileUploadPayloadsTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/FileUploadPayloadsTest.java
@@ -1,3 +1,22 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.apiaddicts.apitools.dosonarapi.api.v31;
 
 import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/FileUploadPayloadsTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/FileUploadPayloadsTest.java
@@ -1,0 +1,33 @@
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class FileUploadPayloadsTest extends BaseNodeTest<OpenApi31Grammar> {
+
+  @Test
+  public void can_parse_upload_binary_post() {
+    JsonNode node = parseResource(OpenApi31Grammar.PATHS, "/models/v31/binarypost.yaml");
+
+    assertPropertyKeys(node).containsOnly("/upload");
+
+  }
+
+  @Test
+  public void can_parse_upload_img64() {
+    JsonNode node = parseResource(OpenApi31Grammar.PATHS, "/models/v31/imgbase64.yaml");
+
+    assertPropertyKeys(node).containsOnly("/upload-image");
+
+  }
+
+  @Test
+  public void can_parse_upload_multipart() {
+    JsonNode node = parseResource(OpenApi31Grammar.PATHS, "/models/v31/multipart.yaml");
+
+    assertPropertyKeys(node).containsOnly("/upload-multipart");
+
+  }
+
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/JsonSchemaTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/JsonSchemaTest.java
@@ -1,3 +1,22 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.apiaddicts.apitools.dosonarapi.api.v31;
 
 import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/JsonSchemaTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/JsonSchemaTest.java
@@ -1,0 +1,32 @@
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class JsonSchemaTest extends BaseNodeTest<OpenApi31Grammar> {
+
+    @Test
+    public void json_$schema_schema() {
+    JsonNode node = parseResource(OpenApi31Grammar.SCHEMA, "/models/v31/jsonschemaschema.yaml");
+
+    assertEquals("https://json-schema.org/draft/2020-12/schema", node, "/$schema");  
+    }
+
+    @Test
+    public void json_$schema_link() {
+    JsonNode node = parseResource(OpenApi31Grammar.LINK, "/models/v31/jsonschemalink.yaml");
+
+    JsonNode param = node.at("/parameters");
+    assertEquals("getExample", param, "/operationId");
+    assertEquals("http://json-schema.org/draft-07/schema#", param, "/exampleParam/$schema");
+    }
+
+    @Test
+    public void json_$schema_example() {
+    JsonNode node = parseResource(OpenApi31Grammar.EXAMPLE, "/models/v31/jsonschemaexample.yaml");
+
+    JsonNode param = node.at("/value");
+    assertEquals("http://json-schema.org/draft-07/schema#", param, "/$schema");
+    }
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/MutualTLSTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/MutualTLSTest.java
@@ -1,0 +1,43 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.api.v3.OpenApi3Grammar;
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class MutualTLSTest extends BaseNodeTest<OpenApi31Grammar> {
+
+  @Test
+  public void mutualtls() {
+    JsonNode node = parseResource(OpenApi31Grammar.PATHS, "/models/v31/mutualtls.yaml");
+
+    assertPropertyKeys(node).containsOnly("/secure-endpoint");
+
+  }
+
+  @Test
+    public void can_parse_secure_components_with_mutual_tls() {
+        JsonNode node = parseResource(OpenApi31Grammar.MUTUALTLS_SECURITY_SCHEME, "/models/v31/mutualtlscomponents.yaml");
+
+        assertPropertyKeys(node).containsOnly("type");
+    }
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/NullableObjectTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/NullableObjectTest.java
@@ -1,0 +1,37 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class NullableObjectTest extends BaseNodeTest<OpenApi31Grammar> {
+
+  @Test
+  public void nullable_schema_object() {
+    JsonNode node = parseResource(OpenApi31Grammar.SCHEMA, "/models/v31/nullableobject.yaml");
+
+    assertElements(node, "/properties/name/type").containsExactly("string", "null");
+    assertElements(node, "/properties/age/type").containsExactly("integer", "null");
+
+}
+}
+

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/OAuthTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/OAuthTest.java
@@ -1,0 +1,5 @@
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+public class OAuthTest {
+    
+}

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/OAuthTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/OAuthTest.java
@@ -1,3 +1,22 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.apiaddicts.apitools.dosonarapi.api.v31;
 
 public class OAuthTest {

--- a/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/WebhooksTest.java
+++ b/openapi-front-end/src/test/java/org/apiaddicts/apitools/dosonarapi/api/v31/WebhooksTest.java
@@ -1,0 +1,33 @@
+/*
+ * doSonarAPI: SonarQube OpenAPI Plugin
+ * Copyright (C) 2021-2022 Apiaddicts
+ * contacta AT apiaddicts DOT org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.apiaddicts.apitools.dosonarapi.api.v31;
+
+import org.apiaddicts.apitools.dosonarapi.openapi.BaseNodeTest;
+import org.junit.Test;
+import org.apiaddicts.apitools.dosonarapi.sslr.yaml.grammar.JsonNode;
+
+public class WebhooksTest extends BaseNodeTest<OpenApi31Grammar> {
+  @Test
+  public void component_webhook() {
+    JsonNode node = parseResource(OpenApi31Grammar.COMPONENTS, "/models/v31/webhook.yaml");
+
+    assertPropertyKeys(node).containsOnly("webhooks");
+  }
+}

--- a/openapi-front-end/src/test/resources/models/v31/binarypost.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/binarypost.yaml
@@ -1,0 +1,9 @@
+/upload:
+  post:
+    summary: Upload a binary file
+    requestBody:
+      content:
+        application/octet-stream: {}
+    responses:
+      "200":
+        description: File uploaded successfully

--- a/openapi-front-end/src/test/resources/models/v31/examples.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/examples.yaml
@@ -1,0 +1,6 @@
+properties:
+  os:
+    type: string
+    examples:
+      - fedora
+      - ubuntu

--- a/openapi-front-end/src/test/resources/models/v31/fileupload.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/fileupload.yaml
@@ -1,0 +1,14 @@
+/uploadMultipart:
+  post:
+    summary: Upload a file with multipart/form-data
+    requestBody:
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              orderId:
+                type: integer
+              fileName:
+                type: string
+                contentMediaType: application/octet-stream

--- a/openapi-front-end/src/test/resources/models/v31/imgbase64.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/imgbase64.yaml
@@ -1,0 +1,12 @@
+/upload-image:
+  post:
+    summary: Upload an image with base64 encoding
+    requestBody:
+      content:
+        image/png:
+          schema:
+            type: string
+            contentEncoding: base64
+    responses:
+      "200":
+        description: Image uploaded successfully

--- a/openapi-front-end/src/test/resources/models/v31/jsonschemaexample.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/jsonschemaexample.yaml
@@ -1,0 +1,2 @@
+value:
+        $schema: "http://json-schema.org/draft-07/schema#"

--- a/openapi-front-end/src/test/resources/models/v31/jsonschemalink.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/jsonschemalink.yaml
@@ -1,0 +1,5 @@
+parameters:
+    operationId: getExample
+    exampleParam:
+        $schema: "http://json-schema.org/draft-07/schema#"
+

--- a/openapi-front-end/src/test/resources/models/v31/jsonschemaschema.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/jsonschemaschema.yaml
@@ -1,0 +1,1 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"

--- a/openapi-front-end/src/test/resources/models/v31/minimummaximum.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/minimummaximum.yaml
@@ -1,0 +1,7 @@
+properties:
+  age:
+    type: integer
+    exclusiveMinimum: 7
+  price:
+    type: number
+    exclusiveMaximum: 100

--- a/openapi-front-end/src/test/resources/models/v31/multipart.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/multipart.yaml
@@ -1,0 +1,17 @@
+/upload-multipart:
+  post:
+    summary: Upload a multipart file with binary content
+    requestBody:
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              orderId:
+                type: integer
+              fileName:
+                type: string
+                contentMediaType: application/octet-stream
+    responses:
+      "200":
+        description: Multipart file uploaded successfully

--- a/openapi-front-end/src/test/resources/models/v31/mutualtls.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/mutualtls.yaml
@@ -1,0 +1,9 @@
+/secure-endpoint:
+    get:
+      summary: An endpoint secured with mutual TLS and API Key
+      security:
+        - mutualTLS: []
+        - apiKeyAuth: []
+      responses:
+        '200':
+          description: Successful response

--- a/openapi-front-end/src/test/resources/models/v31/mutualtlscomponents.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/mutualtlscomponents.yaml
@@ -1,0 +1,2 @@
+type: mutualTLS
+

--- a/openapi-front-end/src/test/resources/models/v31/nullableobject.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/nullableobject.yaml
@@ -1,0 +1,9 @@
+properties:
+  name:
+    type:
+      - "string"
+      - "null"
+  age:
+    type:
+      - "integer"
+      - "null"

--- a/openapi-front-end/src/test/resources/models/v31/webhook.yaml
+++ b/openapi-front-end/src/test/resources/models/v31/webhook.yaml
@@ -1,0 +1,13 @@
+  webhooks:
+    holaPets:
+      get:
+        description: Returns all pets from the system that the user has access to
+        responses:
+          '200':
+            description: A list of pets.
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Pet'

--- a/openapi-test-tools/pom.xml
+++ b/openapi-test-tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sonar-openapi-plugin/pom.xml
+++ b/sonar-openapi-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.apiaddicts.apitools.dosonarapi</groupId>
     <artifactId>dosonarapi</artifactId>
-    <version>1.0.5</version>
+    <version>1.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

Now, support for OpenAPI 3.1 is included. These are the new changes:

- Introduces support for webhooks, allowing you to describe asynchronous notifications that your API can send to users' systems.
- Replaces the nullable keyword with type arrays, aligning with JSON Schema by allowing multiple types in the type keyword.
- ExclusiveMinimum and ExclusiveMaximum now take distinct values instead of boolean, simplifying their use.
- Replace example with examples inside schema objects, allowing multiple examples in a YAML array format, aligning with JSON Schema.
- Binary file uploads in POST requests no longer require a schema definition, simplifying the process.
- For base64 encoded file uploads, OpenAPI 3.1 uses contentEncoding to specify the encoding.
- For multipart file uploads with binary files, OpenAPI 3.1 uses contentMediaType to specify the media type.
- The $schema keyword is now allowed in OpenAPI 3.1, enabling the definition of the JSON Schema dialect a model uses, which can be different drafts or custom dialects.
- Introduces support for mutual TLS (mTLS), providing two-way authentication between the client and server for enhanced security.
- General improvements in the alignment and clarity of the specification, including enhancements to OAuth 2.0 support.
