### PR TITLE
fix: cve alert with guava 32 in sslr-yaml-parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.1] - 2024-05-14
+## [1.2.1] - 2024-05-22
 
-## Fixed
+### Security
+
+- Update `sslr-yaml-parser` to resolve transitive `guava` vulnerabilities.
+
+### Fixed
 
 - Resolve language suffix conflict between the plugin's custom YAML/JSON support and SonarQube's built-in language detection.
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <sonar.analyzer.commons.version>1.22.0.848</sonar.analyzer.commons.version>
     <sonar.orchestrator.version>3.37.0.87</sonar.orchestrator.version>
     <sslr.version>1.24.0.633</sslr.version>
-    <sslr.yaml.version>1.0.0</sslr.yaml.version>
+    <sslr.yaml.version>1.0.1</sslr.yaml.version>
   </properties>
 
   <build>


### PR DESCRIPTION
fix: cve alert with guava 32 in sslr-yaml-parser 1.0.1

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
